### PR TITLE
XEN_SYSCTL_numainfo: memsize: Count e820 RAM pages of NUMA nodes

### DIFF
--- a/xen/arch/x86/include/asm/numa.h
+++ b/xen/arch/x86/include/asm/numa.h
@@ -55,6 +55,7 @@ extern u8 *memnodemap;
 struct node_data {
     unsigned long node_start_pfn;
     unsigned long node_spanned_pages;
+    unsigned long node_present_pages;
 };
 
 extern struct node_data node_data[];
@@ -72,6 +73,7 @@ static inline __attribute__((pure)) nodeid_t phys_to_nid(paddr_t addr)
 
 #define node_start_pfn(nid)	(NODE_DATA(nid)->node_start_pfn)
 #define node_spanned_pages(nid)	(NODE_DATA(nid)->node_spanned_pages)
+#define node_present_pages(nid) (NODE_DATA(nid)->node_present_pages)
 #define node_end_pfn(nid)       (NODE_DATA(nid)->node_start_pfn + \
 				 NODE_DATA(nid)->node_spanned_pages)
 #define arch_want_default_dmazone() (num_online_nodes() > 1)

--- a/xen/common/sysctl.c
+++ b/xen/common/sysctl.c
@@ -316,7 +316,7 @@ long do_sysctl(XEN_GUEST_HANDLE_PARAM(xen_sysctl_t) u_sysctl)
                 {
                     if ( node_online(i) )
                     {
-                        meminfo.memsize = node_spanned_pages(i) << PAGE_SHIFT;
+                        meminfo.memsize = node_present_pages(i) << PAGE_SHIFT;
                         meminfo.memfree = avail_node_heap_pages(i) << PAGE_SHIFT;
                     }
                     else


### PR DESCRIPTION
## Background
The Xen Hypercall command `XEN_SYSCTL_numainfo` returns the `memsize` and `memsize` for each 
NUMA node, which is shown by `xl info -n` and `xl debug-keys u`:

`xl info -n`:
```py
numa_info              :
node:    memsize    memfree    distances
   0:     67584      60672      10,21
   1:     65536      60958      21,10
```
`xl debug-keys u && xl dmesg | tail`:
```
(XEN) [3547369.095546] NODE0 start->0 size->17301504 free->15532159
(XEN) [3547369.095549] NODE1 start->17301504 size->16777216 free->15605362
```
## Issue
The returned `memsize` values for the NUMA nodes are calculated from `NODE_DATA->node_spanned_pages`, which is usually wrong for the 1st NUMA on x86 hardware, as on x86, there are usually memory holes and the `node_spanned_pages` includes those holes.

Both SRAT and the e820 tables show these holes. Example SRAT with a 2GB hole for Node 0:
```py
xl dmesg |grep SRAT
(XEN) [002fe30deadcf9f2] ACPI: SRAT 6C041000, 2830 (r3 INTEL  S2600WF         2 INTL 20091013)
(XEN) [002fe30e22582ac0] SRAT: Node 0 PXM 0 [0000000000000000, 000000007fffffff]  # 2G hole until 100000000
(XEN) [002fe30e233b5532] SRAT: Node 0 PXM 0 [0000000100000000, 000000107fffffff]
(XEN) [002fe30e241e80fc] SRAT: Node 1 PXM 1 [0000001080000000, 000000207fffffff]
```

## Details

`XEN_SYSCTL_numainfo` returns `memfree` and `memsize` of each NUMA node, and `memsize` returns `NODE_DATA->node_spanned_pages` that includes memory holes which are not usable memory.

These holes cause that the 1st NUMA node is reported to be e.g. ~2GB larger than it really is.

Those holes are part of the e820 table and the `SRAT` and `nodes_cover_memory` which that the `SRAT` covers all `E820_RAM` areas, but E820_RAM may omit more areas (e.g. reserved), so the e820 table is more exact.

This patch counts the present pages in the NUMA nodes based on the e820 RAM entries, which may report e.g. 63.5 GB for node0 where the SRAT entries my report 64GB, but the 63.5 GB is what is actually accessible as E820_RAM.