### PR TITLE
Fix `XEN_SYSCTL_numainfo[].memsize`: Report E820_RAM pages as memsize

### DIFF
--- a/xen/arch/x86/x86_64/mm.c
+++ b/xen/arch/x86/x86_64/mm.c
@@ -1333,6 +1333,8 @@ int memory_add(unsigned long spfn, unsigned long epfn, unsigned int pxm)
     /* We can't revert any more */
     share_hotadd_m2p_table(&info);
     transfer_pages_to_heap(&info);
+    /* Update the node's present pages (like the total_pages of the system) */
+    NODE_DATA(node)->node_present_pages += epfn - spfn;
 
     return 0;
 

--- a/xen/common/sysctl.c
+++ b/xen/common/sysctl.c
@@ -316,7 +316,7 @@ long do_sysctl(XEN_GUEST_HANDLE_PARAM(xen_sysctl_t) u_sysctl)
                 {
                     if ( node_online(i) )
                     {
-                        meminfo.memsize = node_spanned_pages(i) << PAGE_SHIFT;
+                        meminfo.memsize = node_present_pages(i) << PAGE_SHIFT;
                         meminfo.memfree = avail_node_heap_pages(i) << PAGE_SHIFT;
                     }
                     else

--- a/xen/include/xen/numa.h
+++ b/xen/include/xen/numa.h
@@ -71,6 +71,7 @@ extern nodeid_t *memnodemap;
 struct node_data {
     unsigned long node_start_pfn;
     unsigned long node_spanned_pages;
+    unsigned long node_present_pages;
 };
 
 extern struct node_data node_data[];
@@ -91,6 +92,7 @@ static inline nodeid_t mfn_to_nid(mfn_t mfn)
 
 #define node_start_pfn(nid)     (NODE_DATA(nid)->node_start_pfn)
 #define node_spanned_pages(nid) (NODE_DATA(nid)->node_spanned_pages)
+#define node_present_pages(nid) (NODE_DATA(nid)->node_present_pages)
 #define node_end_pfn(nid)       (NODE_DATA(nid)->node_start_pfn + \
                                  NODE_DATA(nid)->node_spanned_pages)
 
@@ -123,6 +125,7 @@ extern void numa_set_processor_nodes_parsed(nodeid_t node);
 extern mfn_t first_valid_mfn;
 
 #define node_spanned_pages(nid) (max_page - mfn_x(first_valid_mfn))
+#define node_present_pages(nid) total_pages
 #define node_start_pfn(nid) mfn_x(first_valid_mfn)
 #define __node_distance(a, b) 20
 


### PR DESCRIPTION
Fix the NUMA node's `memsize` reported by `XEN_SYSCTL_numainfo`:

Add up the present E820_RAM pages for the NUMA node(excludes holes)

The Xen Hypercall command `XEN_SYSCTL_numainfo` returns `memsize` and `memsize` for each NUMA node.

It is shown by `xl info -n` (and `xl debug-keys u`):
```py
node:    memsize    memfree    distances
   0:     67584      60672      10,21  <- memsize incorrect: +2048MB
   1:     65536      60958      21,10
```
The incorrect `memsize` is calculated from `NODE_DATA->node_spanned_pages`, which is usually wrong for the first NUMA node on x86 hardware:

On x86, MMIO memory holes are included in `node_spanned_pages`.

Those holes are part of the e820 table and the `SRAT`. An example `SRAT` with a 2GB hole for Node 0:
```py
xl dmesg |grep SRAT
(XEN) ACPI: SRAT 6C041000, 2830 (r3 INTEL S2600WF 2 INTL 20091013)
(XEN) SRAT: Node 0 PXM 0 [0000000000000000, 000000007fffffff]
----> Here, the SRAT leaves a 2GB gap for the 2GB MMIO hole <----
(XEN) SRAT: Node 0 PXM 0 [0000000100000000, 000000107fffffff]
(XEN) SRAT: Node 1 PXM 1 [0000001080000000, 000000207fffffff]
```

The `SRAT` is checked by `nodes_cover_memory()` to cover all `E820_RAM` areas, but the `SRAT` does not have to show all holes.

E820_RAM may declare other areas (e.g. reserved), so the e820 table is expected to be the authoritative information on usable RAM regions.

This patch gets the sum of E820_RAM entries in all NUMA nodes and uses those present pages for `XEN_SYSCTL_numainfo.memsize` of each NUMA node.

If we'd use the `SRAT` instead of e820, in this example, the result would be 64GB for node0.

By adding up only E820 RAM, this patch arrives at 63.5GB usable memory for NUMA node0 on this example system. This is likely due to additional reserved areas in the lower e820 address ranges like SMM memory.